### PR TITLE
Try Leeway Seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
+  - 1.12.x
   - 1.13.x
   - tip
 

--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -75,7 +75,7 @@ func (j *JwtVerifier) New() *JwtVerifier {
 
 func (j *JwtVerifier) SetLeeway(duration string) {
 	dur, _ := time.ParseDuration(duration)
-	j.leeway = dur.Milliseconds() / 1000
+	j.leeway = int64(dur.Seconds())
 }
 
 func (j *JwtVerifier) VerifyAccessToken(jwt string) (*Jwt, error) {

--- a/utils/parseEnv.go
+++ b/utils/parseEnv.go
@@ -34,7 +34,6 @@ func ParseEnvironment() {
 	setEnvVariable("ISSUER", os.Getenv("ISSUER"))
 	setEnvVariable("USERNAME", os.Getenv("USERNAME"))
 	setEnvVariable("PASSWORD", os.Getenv("PASSWORD"))
-	log.Printf(os.Getenv("USERNAME"))
 	if os.Getenv("CLIENT_ID") == "" {
 		log.Printf("Could not resolve a CLIENT_ID environment variable.")
 		os.Exit(1)


### PR DESCRIPTION
`Milliseconds()` was added in 1.13, causing us to not be able to use 1.12 anymore.

This change makes it so we use `Seconds()` instead  (for leeway) so we can now use 1.12