### PR TITLE
Allow other header claims to be present when verifying a JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v1.1.2
+
+### Updates
+
+- Only `alg` and `kid` claims in a JWT header are considered during verification.

--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -331,24 +331,14 @@ func (j *JwtVerifier) isValidJwt(jwt string) (bool, error) {
 		return false, fmt.Errorf("the tokens header is not a json object")
 	}
 
-	if len(jsonObject) < 2 {
-		return false, fmt.Errorf("the tokens header does not contain enough properties. " +
-			"Should contain `alg` and `kid`")
-	}
-
-	if len(jsonObject) > 2 {
-		return false, fmt.Errorf("the tokens header contains too many properties. " +
-			"Should only contain `alg` and `kid`")
-	}
-
 	_, algExists := jsonObject["alg"]
 	_, kidExists := jsonObject["kid"]
 
-	if algExists == false {
+	if !algExists {
 		return false, fmt.Errorf("the tokens header must contain an 'alg'")
 	}
 
-	if kidExists == false {
+	if !kidExists {
 		return false, fmt.Errorf("the tokens header must contain a 'kid'")
 	}
 

--- a/jwtverifier_test.go
+++ b/jwtverifier_test.go
@@ -218,19 +218,7 @@ func Test_an_id_token_header_that_is_not_contain_the_correct_parts_throws_an_err
 
 	jv := jvs.New()
 
-	_, err := jv.VerifyIdToken("ew0KICAidGVzdCI6ICJ0aGlzIg0KfQ.aa.aa")
-
-	if !strings.Contains(err.Error(), "header does not contain enough properties") {
-		t.Errorf("the error for id token with header that does not contain enough properties did not trigger")
-	}
-
-	_, err = jv.VerifyIdToken("ew0KICAidGVzdCI6ICJ0aGlzIiwNCiAgImFuZCI6ICJ0aGlzIiwNCiAgImhlbGxvIjogIndvcmxkIg0KfQ.aa.aa")
-
-	if !strings.Contains(err.Error(), "header contains too many properties") {
-		t.Errorf("the error for id token with header that contains too many properties did not trigger")
-	}
-
-	_, err = jv.VerifyIdToken("ew0KICAia2lkIjogImFiYzEyMyIsDQogICJhbmQiOiAidGhpcyINCn0.aa.aa")
+	_, err := jv.VerifyIdToken("ew0KICAia2lkIjogImFiYzEyMyIsDQogICJhbmQiOiAidGhpcyINCn0.aa.aa")
 
 	if !strings.Contains(err.Error(), "header must contain an 'alg'") {
 		t.Errorf("the error for id token with header that did not contain alg did not trigger")
@@ -311,20 +299,7 @@ func Test_an_access_token_header_that_is_not_contain_the_correct_parts_throws_an
 
 	jv := jvs.New()
 
-	_, err := jv.VerifyAccessToken("ew0KICAidGVzdCI6ICJ0aGlzIg0KfQ.aa.aa")
-
-	if !strings.Contains(err.Error(), "header does not contain enough properties") {
-		t.Errorf("the error for access token with header that does not contain enough properties did not" +
-			" trigger")
-	}
-
-	_, err = jv.VerifyAccessToken("ew0KICAidGVzdCI6ICJ0aGlzIiwNCiAgImFuZCI6ICJ0aGlzIiwNCiAgImhlbGxvIjogIndvcmxkIg0KfQ.aa.aa")
-
-	if !strings.Contains(err.Error(), "header contains too many properties") {
-		t.Errorf("the error for access token with header that contains too many properties did not trigger")
-	}
-
-	_, err = jv.VerifyAccessToken("ew0KICAia2lkIjogImFiYzEyMyIsDQogICJhbmQiOiAidGhpcyINCn0.aa.aa")
+	_, err := jv.VerifyAccessToken("ew0KICAia2lkIjogImFiYzEyMyIsDQogICJhbmQiOiAidGhpcyINCn0.aa.aa")
 
 	if !strings.Contains(err.Error(), "header must contain an 'alg'") {
 		t.Errorf("the error for access token with header that did not contain alg did not trigger")


### PR DESCRIPTION
There can be other claims in a JWT header that do not relate to the Okta JWT verifier. The verifier is only concerned that `alg` algorithm and `kid` key identifier header claims are present. Currently, JWTs for [Okta FastPass](https://www.okta.com/fastpass/) can include the a media type header claim `typ`.

This PR addresses #67 and is @euforic's work from #68.