### PR TITLE
Add ability to accept multiple aud claims in a JWT

### DIFF
--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -219,6 +219,17 @@ func (j *JwtVerifier) validateAudience(audience interface{}) error {
 			}
 		}
 		return fmt.Errorf("aud: %s does not match %s", v, j.ClaimsToValidate["aud"])
+	case []interface{}:
+		for _, e := range v {
+			element, ok := e.(string)
+			if !ok {
+				return fmt.Errorf("Unknown type for audience validation")
+			}
+			if element == j.ClaimsToValidate["aud"] {
+				return nil
+			}
+		}
+		return fmt.Errorf("aud: %s does not match %s", v, j.ClaimsToValidate["aud"])
 	default:
 		return fmt.Errorf("Unknown type for audience validation")
 	}


### PR DESCRIPTION
Obvious Fix

json.Unmarshal will return []interface{}, instead of []string, which causes some issues when multiple aud claims are sent.

This PR expands the ability of validateAudience to work with this possible type.