### PR TITLE
Address interface slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,11 @@
 ### Updates
 
 - Only `alg` and `kid` claims in a JWT header are considered during verification.
+
+## v1.1.3
+
+### Updates
+
+- Fixed edge cause with `aud` claim that would not find Auth0 being JWTs valid (thank you @awrenn).
+- Updated readme with testing notes.
+- Ran `gofumpt` on code for clean up.

--- a/README.md
+++ b/README.md
@@ -81,3 +81,23 @@ verifier.SetLeeway("2m") //String instance of time that will be parsed by `time.
 ```
 
 [Okta Developer Forum]: https://devforum.okta.com/
+
+## Testing
+
+If you create a PR from a fork of okta/okta-jwt-verifier-golang the build for
+the PR will fail. Don't worry, we'll bring your commits into a review branch in
+okta/okta-jwt-verifier-golang and get a green build.
+
+jwtverifier_test.go expects environment variables for `ISSUER`, `CLIENT_ID`,
+`USERNAME`, and `PASSWORD` to be present. Take note if you use zshell as
+`USERSNAME` is a special environment variable and is not settable. Therefore
+tests shouldn't be run in zshell.
+
+`USERNAME` and `PASSWORD` are for a user with access to the test app associated
+with `CLIENT_ID`. The test app should not have 2FA enabled and allow password
+login. The General Settings for the test app should have Application Grant type
+with Implicit (hybrid) enabled.
+
+```
+go test -test.v
+```

--- a/adaptors/lestrratGoJwx/lestrratGoJwx.go
+++ b/adaptors/lestrratGoJwx/lestrratGoJwx.go
@@ -28,8 +28,10 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-var jwkSetCache *cache.Cache = cache.New(5*time.Minute, 10*time.Minute)
-var jwkSetMu = &sync.Mutex{}
+var (
+	jwkSetCache *cache.Cache = cache.New(5*time.Minute, 10*time.Minute)
+	jwkSetMu                 = &sync.Mutex{}
+)
 
 func getJwkSet(jwkUri string) (jwk.Set, error) {
 	jwkSetMu.Lock()
@@ -39,7 +41,6 @@ func getJwkSet(jwkUri string) (jwk.Set, error) {
 		return x.(jwk.Set), nil
 	}
 	jwkSet, err := jwk.Fetch(context.Background(), jwkUri)
-
 	if err != nil {
 		return nil, err
 	}
@@ -58,17 +59,14 @@ func (lgj LestrratGoJwx) New() adaptors.Adaptor {
 }
 
 func (lgj LestrratGoJwx) GetKey(jwkUri string) {
-	return
 }
 
 func (lgj LestrratGoJwx) Decode(jwt string, jwkUri string) (interface{}, error) {
 	jwkSet, err := getJwkSet(jwkUri)
-
 	if err != nil {
 		return nil, err
 	}
 	token, err := jws.VerifySet([]byte(jwt), jwkSet)
-
 	if err != nil {
 		return nil, err
 	}
@@ -78,5 +76,4 @@ func (lgj LestrratGoJwx) Decode(jwt string, jwkUri string) (interface{}, error) 
 	json.Unmarshal(token, &claims)
 
 	return claims, nil
-
 }

--- a/discovery/oidc/oidc.go
+++ b/discovery/oidc/oidc.go
@@ -18,7 +18,7 @@ package oidc
 
 import "github.com/okta/okta-jwt-verifier-golang/discovery"
 
-type Oidc struct{
+type Oidc struct {
 	wellKnownUrl string
 }
 

--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -219,6 +219,17 @@ func (j *JwtVerifier) validateAudience(audience interface{}) error {
 			}
 		}
 		return fmt.Errorf("aud: %s does not match %s", v, j.ClaimsToValidate["aud"])
+	case []interface{}:
+		for _, e := range v {
+			element, ok := e.(string)
+			if !ok {
+				return fmt.Errorf("Unknown type for audience validation")
+			}
+			if element == j.ClaimsToValidate["aud"] {
+				return nil
+			}
+		}
+		return fmt.Errorf("aud: %s does not match %s", v, j.ClaimsToValidate["aud"])
 	default:
 		return fmt.Errorf("Unknown type for audience validation")
 	}

--- a/jwtverifier_test.go
+++ b/jwtverifier_test.go
@@ -350,12 +350,11 @@ func Test_a_successful_authentication_can_have_its_tokens_parsed(t *testing.T) {
 	postValues := map[string]string{"username": os.Getenv("USERNAME"), "password": os.Getenv("PASSWORD")}
 	postJsonValues, _ := json.Marshal(postValues)
 	resp, err := http.Post(requestUri, "application/json", bytes.NewReader(postJsonValues))
-
 	if err != nil {
 		t.Errorf("could not submit authentication endpoint")
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, _ := ioutil.ReadAll(resp.Body)
 
 	var authn AuthnResponse
 	err = json.Unmarshal(body, &authn)
@@ -406,7 +405,6 @@ func Test_a_successful_authentication_can_have_its_tokens_parsed(t *testing.T) {
 	}
 
 	claims, err := jv.New().VerifyIdToken(idToken)
-
 	if err != nil {
 		t.Errorf("could not verify id_token: %s", err.Error())
 	}

--- a/utils/nonce.go
+++ b/utils/nonce.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
-	"fmt"
-	"encoding/base64"
 	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 )
 
 func GenerateNonce() (string, error) {

--- a/utils/parseEnv.go
+++ b/utils/parseEnv.go
@@ -24,10 +24,8 @@ import (
 )
 
 func ParseEnvironment() {
-	//useGlobalEnv := true
 	if _, err := os.Stat(".env"); os.IsNotExist(err) {
 		log.Printf("Environment Variable file (.env) is not present.  Relying on Global Environment Variables")
-		//useGlobalEnv = false
 	}
 
 	setEnvVariable("CLIENT_ID", os.Getenv("CLIENT_ID"))
@@ -43,8 +41,8 @@ func ParseEnvironment() {
 		log.Printf("Could not resolve a ISSUER environment variable.")
 		os.Exit(1)
 	}
-
 }
+
 func setEnvVariable(env string, current string) {
 	if current != "" {
 		return


### PR DESCRIPTION
Okta-fied PR of @awrenn's original PR #73 work

> Obvious Fix
> json.Unmarshal will return []interface{}, instead of []string, which causes some issues when multiple aud claims are sent.
> This PR expands the ability of validateAudience to work with this possible type.