### PR TITLE
Configurable cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library was built to keep configuration to a minimum. To get it running at 
 
 #### Access Token Validation
 ```go
-import github.com/okta/okta-jwt-verifier-golang
+import "github.com/okta/okta-jwt-verifier-golang"
 
 toValidate := map[string]string{}
 toValidate["aud"] = "api://default"
@@ -44,7 +44,7 @@ token, err := verifier.VerifyAccessToken("{JWT}")
 
 #### Id Token Validation
 ```go
-import github.com/okta/okta-jwt-verifier-golang
+import "github.com/okta/okta-jwt-verifier-golang"
 
 toValidate := map[string]string{}
 toValidate["nonce"] = "{NONCE}"

--- a/jwtverifier_test.go
+++ b/jwtverifier_test.go
@@ -54,7 +54,7 @@ func Test_the_verifier_defaults_to_lestrratGoJwx_if_nothing_is_provided_for_adap
 
 	jv := jvs.New()
 
-	if reflect.TypeOf(jv.GetAdaptor()) != reflect.TypeOf(lestrratGoJwx.LestrratGoJwx{}) {
+	if reflect.TypeOf(jv.GetAdaptor()) != reflect.TypeOf(&lestrratGoJwx.LestrratGoJwx{}) {
 		t.Errorf("adaptor did not set to lestrratGoJwx by default.  Was set to: %s",
 			reflect.TypeOf(jv.GetAdaptor()))
 	}

--- a/utils/cache.go
+++ b/utils/cache.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// Cacher is a read-only cache interface.
+//
+// Get returns the value associated with the given key.
+type Cacher interface {
+	Get(string) (interface{}, error)
+}
+
+type defaultCache struct {
+	cache  *cache.Cache
+	lookup func(string) (interface{}, error)
+	mutex  *sync.Mutex
+}
+
+func (c *defaultCache) Get(key string) (interface{}, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if value, found := c.cache.Get(key); found {
+		return value, nil
+	}
+
+	value, err := c.lookup(key)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache.SetDefault(key, value)
+	return value, nil
+}
+
+// defaultCache implements the Cacher interface
+var _ Cacher = (*defaultCache)(nil)
+
+// NewDefaultCache returns cache with a 5 minute expiration.
+func NewDefaultCache(lookup func(string) (interface{}, error)) (Cacher, error) {
+	return &defaultCache{
+		cache:  cache.New(5*time.Minute, 10*time.Minute),
+		lookup: lookup,
+		mutex:  &sync.Mutex{},
+	}, nil
+}

--- a/utils/cache_example_test.go
+++ b/utils/cache_example_test.go
@@ -1,0 +1,50 @@
+package utils_test
+
+import (
+	"fmt"
+
+	jwtverifier "github.com/okta/okta-jwt-verifier-golang"
+	"github.com/okta/okta-jwt-verifier-golang/utils"
+)
+
+// ForeverCache caches values forever
+type ForeverCache struct {
+	values map[string]interface{}
+	lookup func(string) (interface{}, error)
+}
+
+// Get returns the value for the given key
+func (c *ForeverCache) Get(key string) (interface{}, error) {
+	value, ok := c.values[key]
+	if ok {
+		return value, nil
+	}
+	value, err := c.lookup(key)
+	if err != nil {
+		return nil, err
+	}
+	c.values[key] = value
+	return value, nil
+}
+
+// ForeverCache implements the read-only Cacher interface
+var _ utils.Cacher = (*ForeverCache)(nil)
+
+// NewForeverCache takes a lookup function and returns a cache
+func NewForeverCache(lookup func(string) (interface{}, error)) (utils.Cacher, error) {
+	return &ForeverCache{
+		values: map[string]interface{}{},
+		lookup: lookup,
+	}, nil
+}
+
+// Example demonstrating how the JwtVerifier can be configured with a custom Cache function.
+func Example() {
+	jwtVerifierSetup := jwtverifier.JwtVerifier{
+		Cache: NewForeverCache,
+		// other fields here
+	}
+
+	verifier := jwtVerifierSetup.New()
+	fmt.Println(verifier)
+}

--- a/utils/cache_test.go
+++ b/utils/cache_test.go
@@ -1,0 +1,50 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/okta/okta-jwt-verifier-golang/utils"
+)
+
+type Value struct {
+	key string
+}
+
+func TestNewDefaultCache(t *testing.T) {
+	lookup := func(key string) (interface{}, error) {
+		return &Value{key: key}, nil
+	}
+
+	cache, err := utils.NewDefaultCache(lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	first, firstErr := cache.Get("first")
+	if firstErr != nil {
+		t.Fatalf("Expected no error, got %v", firstErr)
+	}
+	if _, ok := first.(*Value); !ok {
+		t.Error("Expected first to be a *Value")
+	}
+
+	second, secondErr := cache.Get("second")
+	if secondErr != nil {
+		t.Fatalf("Expected no error, got %v", secondErr)
+	}
+	if _, ok := second.(*Value); !ok {
+		t.Error("Expected second to be a *Value")
+	}
+
+	if first == second {
+		t.Error("Expected first and second to be different")
+	}
+
+	firstAgain, firstAgainErr := cache.Get("first")
+	if firstAgainErr != nil {
+		t.Fatalf("Expected no error, got %v", firstAgainErr)
+	}
+	if first != firstAgain {
+		t.Error("Expected cached value to be the same")
+	}
+}


### PR DESCRIPTION
This adds a `Cache` field to the `JwtVerifier` struct.  If provided, the `Cache` function is called to create a new metadata cache.  The same function is passed to the default adapter to cache JWK resources.  By default, a cache with a 5 minute expiry is used (as it is currently).

Fixes #37.