### PR TITLE
Fix possible cache construction race condition

### DIFF
--- a/adaptors/lestrratGoJwx/lestrratGoJwx.go
+++ b/adaptors/lestrratGoJwx/lestrratGoJwx.go
@@ -42,6 +42,13 @@ func (lgj *LestrratGoJwx) New() adaptors.Adaptor {
 		lgj.Cache = utils.NewDefaultCache
 	}
 
+	var err error
+	lgj.jwkSetCache, err = lgj.Cache(fetchJwkSet)
+	if err != nil {
+		// maybe panic(err)
+		lgj.jwkSetCache = nil
+	}
+
 	return lgj
 }
 

--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -97,6 +97,13 @@ func (j *JwtVerifier) New() *JwtVerifier {
 	// Default to PT2M Leeway
 	j.leeway = 120
 
+	var err error
+	j.metadataCache, err = j.Cache(fetchMetaData)
+	if err != nil {
+		// maybe panic(err)
+		j.metadataCache = nil
+	}
+
 	return j
 }
 


### PR DESCRIPTION
The addition of a configurable cache (#76/#78) seems to have introduced a possible race condition where multiple goroutines could construct the caches. I discovered this while running tests for some code which used `VerifyAccessToken` on multiple goroutines when using the Go race detector.

My fix is to move the cache construction to the `New` functions; however, this poses a problem as those functions do not include an error return although the cache constructors could return an error. For now, I have left the later constructor calls in order to punt returning an error to a later call that returns an error. Alternatively, we could either panic with an error (not ideal) or change the interface of the `New` functions to include an error return.