### PR TITLE
Prep v2.1.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-  platform-orb: okta/general-platform-helpers@1.5
+  general-platform-helpers: okta/general-platform-helpers@1.9
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       - run: go version
-      - platform-orb/load-dependencies
+      - general-platform-helpers/step-load-dependencies
       - run:
           name: "test stage"
           command: make test
@@ -24,11 +24,6 @@ jobs:
 workflows:
   "Circle CI Tests":
     jobs:
-      - platform-orb/job-secrets-obtain:
-          name: cache-secrets
-          secret-key: "CLIENT_ID;ISSUER;PASSWORD;USERNAME"
-      - test:
-          requires:
-            - cache-secrets
+      - test
 
 # VS Code Extension Version: 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.1.0 (September 5th, 2024)
+
+### Updates:
+
+Make Audience validation optional [#116](https://github.com/okta/okta-jwt-verifier-golang/pull/116)
+
 ## v2.0.4 (February 26th, 2024)
 
 ### Updates:


### PR DESCRIPTION
## v2.1.0 (September 5th, 2024)

### Updates:

Make Audience validation optional [#116](https://github.com/okta/okta-jwt-verifier-golang/pull/116)