### PR TITLE
update goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.9.1
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
seems like the goreleaser action was updated since our [v2.0.4](https://github.com/okta/okta-jwt-verifier-golang/releases/tag/v2.0.4) release that did not fail.

https://goreleaser.com/deprecations/#-rm-dist

> --rm-dist has been deprecated in favor of --clean.
> since 2023-01-17 (v1.15.0), removed 2024-05-26 (v2.0)