### PR TITLE
Update goreleaser config for version 2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   -
     skip: true
@@ -7,4 +8,4 @@ release:
     name: okta-jwt-verifier-golang
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
goreleaser config needed to be updated as well, last release failed:
https://github.com/okta/okta-jwt-verifier-golang/actions/runs/10744519022/job/29801648279