### PR TITLE
fixes issuer validation when trailing slash is present

### DIFF
--- a/jwtverifier.go
+++ b/jwtverifier.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -352,7 +353,11 @@ func (j *JwtVerifier) validateIss(issuer interface{}) error {
 }
 
 func (j *JwtVerifier) getMetaData() (map[string]interface{}, error) {
-	metaDataUrl := j.Issuer + j.Discovery.GetWellKnownUrl()
+
+	metaDataUrl, err := url.JoinPath(j.Issuer, j.Discovery.GetWellKnownUrl())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create metadata URL:%s", err.Error())
+	}
 
 	value, err := j.metadataCache.Get(metaDataUrl)
 	if err != nil {


### PR DESCRIPTION
The issuer in the JWTVerifier config is used to construct the metadata URL and verify the issuer in the parsed JWT, trailing slashes can cause an issue

for example:
```
2024/10/28 22:19:48 verify err: the `Issuer` was not able to be validated. iss: https://dev-g15esy7pvm6rlcdt.us.auth0.com/ does not match https://dev-g15esy7pvm6rlcdt.us.auth0.com
```

Workaround, pass the trailing slash in the Issuer section, but since a string concatenation is used to construct the metadataURL, a malformed URL will be generated

Solution: use `url.Join` to create the Metadata URL